### PR TITLE
The maximum number of open files semaphore now counts for 3 files at a time,

### DIFF
--- a/src/asyncmd/__about__.py
+++ b/src/asyncmd/__about__.py
@@ -63,7 +63,7 @@ __author_email__ = "hendrik.jung@biophys.mpg.de"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __copyright__ = "2022 {:s}".format(__author__)
 # sort out if we have a git (commit) version
-base_version = "0.2.0.rc1"
+base_version = "0.2.1.rc1"
 git_version = _get_git_version()
 if git_version is None:
     # no git installed

--- a/src/asyncmd/gromacs/mdconfig.py
+++ b/src/asyncmd/gromacs/mdconfig.py
@@ -118,7 +118,25 @@ class MDP(LineBasedMDConfig):
                               "continuation", "unconstrained-start",
                               "morse",
                               ]
-    # TODO: Walls and everything below in the GMX manual
+    # Walls
+    _INT_SINGLETON_PARAMS += ["nwall"]
+    _STR_SINGLETON_PARAMS += ["wall-atomtype", "wall-type"]
+    _FLOAT_SINGLETON_PARAMS += ["wall-r-linpot", "wall-density",
+                                "wall-ewald-zfac"]
+    # COM Pulling
+    _STR_SINGLETON_PARAMS += ["pull", "pull-print-com", "pull-print-ref-value",
+                              "pull-print-components",
+                              "pull-pbc-ref-prev-step-com",
+                              "pull-xout-average", "pull-fout-average",
+                              ]
+    _FLOAT_SINGLETON_PARAMS += ["pull-cylinder-r", "pull-constr-tol",]
+    _INT_SINGLETON_PARAMS += ["pull-nstxout", "pull-nstfout", "pull-ngroups",
+                              "pull-ncoords"]
+    # TODO: COM-Pulling: how to best do everything with a number in the param
+    #       name?! We would like to add e.g. "pull-group1-name" only once but
+    #       would be nice if "pull-group2-name" etc are treated exactly the
+    #       same...
+    # TODO: AWH adaptive biasing and everything below in the GMX manual
 
     def _parse_line(self, line):
         # NOTE: we need to do this so complicated, because gmx accepts

--- a/src/asyncmd/gromacs/mdconfig.py
+++ b/src/asyncmd/gromacs/mdconfig.py
@@ -44,7 +44,7 @@ class MDP(LineBasedMDConfig):
     _KEY_VALUE_SEPARATOR = " = "
     _INTER_VALUE_CHAR = " "
     # MDP param types, sorted into groups/by headings as in the gromacs manual
-    # https://manual.gromacs.org/documentation/5.1/user-guide/mdp-options.html
+    # https://manual.gromacs.org/documentation/current/user-guide/mdp-options.html
     _FLOAT_PARAMS = []
     _FLOAT_SINGLETON_PARAMS = []
     _INT_PARAMS = []
@@ -116,8 +116,7 @@ class MDP(LineBasedMDConfig):
     _STR_SINGLETON_PARAMS += ["constraints", "constraint-algorithm",
                               # the next two are referencing the same option
                               "continuation", "unconstrained-start",
-                              "morse",
-                              ]
+                              "morse"]
     # Walls
     _INT_SINGLETON_PARAMS += ["nwall"]
     _STR_SINGLETON_PARAMS += ["wall-atomtype", "wall-type"]
@@ -127,9 +126,8 @@ class MDP(LineBasedMDConfig):
     _STR_SINGLETON_PARAMS += ["pull", "pull-print-com", "pull-print-ref-value",
                               "pull-print-components",
                               "pull-pbc-ref-prev-step-com",
-                              "pull-xout-average", "pull-fout-average",
-                              ]
-    _FLOAT_SINGLETON_PARAMS += ["pull-cylinder-r", "pull-constr-tol",]
+                              "pull-xout-average", "pull-fout-average"]
+    _FLOAT_SINGLETON_PARAMS += ["pull-cylinder-r", "pull-constr-tol"]
     _INT_SINGLETON_PARAMS += ["pull-nstxout", "pull-nstfout", "pull-ngroups",
                               "pull-ncoords"]
     # Note: gromacs has a maximum of 256 groups, see e.g.
@@ -193,7 +191,93 @@ class MDP(LineBasedMDConfig):
             + [f"awh{n}-dim{d}-cover-diameter"
                for n in range(1, 21) for d in range(1, 5)]
                                 )
-    # TODO: Enforced rotation and everything below in the GMX manual
+    # Enforced rotation
+    # Note: rotation groups are zero indexed, we assume a maximum of 30
+    _STR_SINGLETON_PARAMS += (["rotation"]
+                              + [f"rot-group{n}" for n in range(30)]
+                              + [f"rot-type{n}" for n in range(30)]
+                              + [f"rot-massw{n}" for n in range(30)]
+                              + [f"rot-fit-method{n}" for n in range(30)]
+                              )
+    _INT_SINGLETON_PARAMS += ["rot-ngroups", "rot-nstrout", "rot-nstsout"]
+    _FLOAT_SINGLETON_PARAMS += ([f"rot-rate{n}" for n in range(30)]
+                                + [f"rot-k{n}" for n in range(30)]
+                                + [f"rot-slab-dist{n}" for n in range(30)]
+                                + [f"rot-min-gauss{n}" for n in range(30)]
+                                + [f"rot-eps{n}" for n in range(30)]
+                                + [f"rot-potfit-step{n}" for n in range(30)]
+                                )
+    _FLOAT_PARAMS += ([f"rot-vec{n}" for n in range(30)]
+                      + [f"rot-pivot{n}" for n in range(30)]
+                      )
+    # NMR refinement
+    _STR_SINGLETON_PARAMS += ["disre", "disre-weighting", "disre-mixed",
+                              "orire", "orire-fitgrp"]
+    _FLOAT_SINGLETON_PARAMS += ["disre-fc", "disre-tau", "orire-fc",
+                                "orire-tau"]
+    _INT_SINGLETON_PARAMS += ["nstdisreout", "nstorireout"]
+    # Free energy calculations
+    _STR_SINGLETON_PARAMS += ["free-energy", "expanded", "sc-coul",
+                              "couple-moltype", "couple-lambda0",
+                              "couple-lambda1", "couple-intramol",
+                              "dhdl-derivatives", "dhdl-print-energy",
+                              "separate-dhdl-file"]
+    _FLOAT_SINGLETON_PARAMS += ["init-lambda", "delta-lambda", "sc-alpha",
+                                "sc-sigma", "dh-hist-spacing"]
+    _INT_SINGLETON_PARAMS += ["init-lambda-state", "calc-lambda-neighbors",
+                              "sc-r-power", "sc-power", "nstdhdl",
+                              "dh-hist-size"]
+    _FLOAT_PARAMS += ["fep-lambdas", "coul-lambdas", "vdw-lambdas",
+                      "bonded-lambdas", "restraint-lambdas", "mass-lambdas",
+                      "temperature-lambdas"]
+    # Expanded Ensemble calculations
+    _INT_SINGLETON_PARAMS += ["nstexpanded", "lmc-seed", "lmc-repeats",
+                              "lmc-gibbsdelta", "lmc-forced-nstart",
+                              "nst-transition-matrix", "mininum-var-min"]
+    _STR_SINGLETON_PARAMS += ["lmc-stats", "lmc-mc-move", "wl-oneovert",
+                              "symmetrized-transition-matrix",
+                              "lmc-weights-equil", "simulated-tempering",
+                              "simulated-tempering-scaling"]
+    _FLOAT_SINGLETON_PARAMS += ["mc-temperature", "wl-ratio", "wl-scale",
+                                "init-wl-delta", "sim-temp-low",
+                                "sim-temp-high"]
+    _FLOAT_PARAMS += ["init-lambda-weights"]
+    # Non-equilibrium MD
+    _FLOAT_SINGLETON_PARAMS += ["accelerate", "cos-acceleration"]
+    _FLOAT_PARAMS += ["deform"]
+    # Electric fields
+    _FLOAT_PARAMS += ["electric-field-x", "electric-field-y",
+                      "electric-field-z"]
+    # Mixed quantum/classical molecular dynamics
+    _STR_SINGLETON_PARAMS += ["QMMM", "QMMMscheme", "QMmethod", "QMbasis",
+                              "SH"]
+    _INT_SINGLETON_PARAMS += ["QMcharge", "QMmult", "CASorbitals",
+                              "CASelectrons"]
+    # Implicit solvent
+    _STR_SINGLETON_PARAMS += ["implicit-solvent", "gb-algorithm",
+                              "sa-algorithm"]
+    _INT_SINGLETON_PARAMS += ["nstgbradii"]
+    _FLOAT_SINGLETON_PARAMS += ["rgbradii", "gb-epsilon-solvent",
+                                "gb-saltconc", "gb-obc-alpha", "gb-obc-beta",
+                                "gb-obc-gamma", "gb-dielectric-offset",
+                                "sa-surface-tension"]
+    # Computational Electrophysiology
+    # Note: we assume a maximum of 10 controlled ion types
+    _STR_SINGLETON_PARAMS += (["swapcoords", "split-group0", "split-group1",
+                               "massw-split0", "massw-split1", "solvent-group"]
+                              + [f"iontype{n}-name" for n in range(10)]
+                              )
+    _INT_SINGLETON_PARAMS += (["swap-frequency", "coupl-steps", "iontypes",
+                               "threshold"]
+                              + [f"iontype{n}-in-A" for n in range(10)]
+                              + [f"iontype{n}-in-B" for n in range(10)]
+                              )
+    _FLOAT_SINGLETON_PARAMS += ["bulk-offsetA", "bulk-offsetB", "cyl0-r",
+                                "cyl0-up", "cyl0-down", "cyl1-r", "cyl1-up",
+                                "cyl1-down"]
+    # User defined thingies
+    _INT_SINGLETON_PARAMS += [f"userint{n}" for n in range(1, 5)]
+    _FLOAT_SINGLETON_PARAMS += [f"userreal{n}" for n in range(1, 5)]
 
     def _parse_line(self, line):
         # NOTE: we need to do this so complicated, because gmx accepts

--- a/src/asyncmd/gromacs/mdconfig.py
+++ b/src/asyncmd/gromacs/mdconfig.py
@@ -132,11 +132,68 @@ class MDP(LineBasedMDConfig):
     _FLOAT_SINGLETON_PARAMS += ["pull-cylinder-r", "pull-constr-tol",]
     _INT_SINGLETON_PARAMS += ["pull-nstxout", "pull-nstfout", "pull-ngroups",
                               "pull-ncoords"]
-    # TODO: COM-Pulling: how to best do everything with a number in the param
-    #       name?! We would like to add e.g. "pull-group1-name" only once but
-    #       would be nice if "pull-group2-name" etc are treated exactly the
-    #       same...
-    # TODO: AWH adaptive biasing and everything below in the GMX manual
+    # Note: gromacs has a maximum of 256 groups, see e.g.
+    # https://manual.gromacs.org/current/reference-manual/algorithms/group-concept.html
+    # I (hejung) did not find a maximum for the number of pull coordinates,
+    # but we go with 512 here for now (assuming at most two coords per group)
+    _STR_SINGLETON_PARAMS += (
+            [f"pull-group{n}-name" for n in range(1, 257)]
+            + [f"pull-coord{n}-type" for n in range(1, 513)]
+            + [f"pull-coord{n}-potential-provider" for n in range(1, 513)]
+            + [f"pull-coord{n}-geometry" for n in range(1, 513)]
+            + [f" pull-coord{n}-start" for n in range(1, 513)]
+                              )
+    _FLOAT_SINGLETON_PARAMS += (
+            [f"pull-coord{n}-init" for n in range(1, 513)]
+            + [f"pull-coord{n}-rate" for n in range(1, 513)]
+            + [f"pull-coord{n}-k" for n in range(1, 513)]
+            + [f"pull-coord{n}-kB" for n in range(1, 513)]
+                                )
+    _FLOAT_PARAMS += (
+            [f"pull-group{n}-weights" for n in range(1, 257)]
+            + [f"pull-coord{n}-origin" for n in range(1, 513)]
+            + [f"pull-coord{n}-vec" for n in range(1, 513)]
+                      )
+    _INT_SINGLETON_PARAMS += [f"pull-group{n}-pbcatom" for n in range(1, 257)]
+    _INT_PARAMS += [f"pull-coord{n}-groups" for n in range(1, 513)]
+    # AWH adaptive biasing
+    # Note we assume a maximum number of 20 awh coordinates, each consisting of
+    # a maximum of 4 (pull coordinate) dimensions
+    _STR_SINGLETON_PARAMS += (
+            ["awh", "awh-potential", "awh-share-multisim"]
+            + [f"awh{n}-growth" for n in range(1, 21)]
+            + [f"awh{n}-equilibrate-histogram" for n in range(1, 21)]
+            + [f"awh{n}-target" for n in range(1, 21)]
+            + [f"awh{n}-user-data" for n in range(1, 21)]
+            + [f"awh{n}-dim{d}-coord-provider"
+               for n in range(1, 21) for d in range(1, 5)]
+                              )
+    _INT_SINGLETON_PARAMS += (
+            ["awh-seed", "awh-nstout", "awh-nstsample", "awh-nsamples-update",
+             "awh-nbias"]
+            + [f"awh{n}-share-group" for n in range(1, 21)]
+            + [f"awh{n}-ndim" for n in range(1, 21)]
+            + [f"awh{n}-dim{d}-coord-index"
+               for n in range(1, 21) for d in range(1, 5)]
+                              )
+    _FLOAT_SINGLETON_PARAMS += (
+            [f"awh{n}-error-init" for n in range(1, 21)]
+            + [f"awh{n}-target-beta-scaling" for n in range(1, 21)]
+            + [f"awh{n}-target-cutoff" for n in range(1, 21)]
+            + [f"awh{n}-dim{d}-force-constant"
+               for n in range(1, 21) for d in range(1, 5)]
+            + [f"awh{n}-dim{d}-start"
+               for n in range(1, 21) for d in range(1, 5)]
+            + [f"awh{n}-dim{d}-end"
+               for n in range(1, 21) for d in range(1, 5)]
+            + [f"awh{n}-dim{d}-period"
+               for n in range(1, 21) for d in range(1, 5)]
+            + [f"awh{n}-dim{d}-diffusion"
+               for n in range(1, 21) for d in range(1, 5)]
+            + [f"awh{n}-dim{d}-cover-diameter"
+               for n in range(1, 21) for d in range(1, 5)]
+                                )
+    # TODO: Enforced rotation and everything below in the GMX manual
 
     def _parse_line(self, line):
         # NOTE: we need to do this so complicated, because gmx accepts

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -628,7 +628,8 @@ class GmxEngine(MDEngine):
         # I (hejung) think this is what we want as the prepare methods check
         # for leftover files with the same deffnm, so if only the mdp is there
         # we can (and want to) just ovewrite it without raising an err
-        mdp_obj.write(mdp_in, overwrite=True)
+        async with _SEMAPHORES["MAX_FILES_OPEN"]:
+            mdp_obj.write(mdp_in, overwrite=True)
         mdp_out = os.path.join(workdir, deffnm + "_mdout.mdp")
         cmd_str = self._grompp_cmd(mdp_in=mdp_in, tpr_out=tpr_out,
                                    trr_in=trr_in, mdp_out=mdp_out)
@@ -694,7 +695,8 @@ class GmxEngine(MDEngine):
                         + "continuing anyway."
                         )
         # load the 'old' mdp_in
-        self._mdp = MDP(os.path.join(self.workdir, f"{deffnm}.mdp"))
+        async with _SEMAPHORES["MAX_FILES_OPEN"]:
+            self._mdp = MDP(os.path.join(self.workdir, f"{deffnm}.mdp"))
         self._deffnm = deffnm
         # Note that we dont need to explicitly check for the tpr existing,
         # if it does not exist we will err when getting the traj lengths

--- a/src/asyncmd/trajectory/functionwrapper.py
+++ b/src/asyncmd/trajectory/functionwrapper.py
@@ -492,10 +492,13 @@ class SlurmTrajectoryFunctionWrapper(TrajectoryFunctionWrapper):
             if self.load_results_func is None:
                 # we do not have '.npy' ending in results_file,
                 # numpy.save() adds it if it is not there, so we need it here
-                vals = np.load(result_file + ".npy")
+                async with _SEMAPHORES["MAX_FILES_OPEN"]:
+                    vals = np.load(result_file + ".npy")
                 await aiofiles.os.remove(result_file + ".npy")
             else:
                 # use custom loading function from user
+                # TODO: use the MAX_FILES_OPEN semaphore for the user func too?
+                #       assuming that they need to read to get the vals...?
                 vals = self.load_results_func(result_file)
                 await aiofiles.os.remove(result_file)
             return vals

--- a/src/asyncmd/trajectory/propagate.py
+++ b/src/asyncmd/trajectory/propagate.py
@@ -165,11 +165,12 @@ async def construct_TP_from_plus_and_minus_traj_segments(
                                struct_out=struct_out,
                                overwrite=overwrite)
     loop = asyncio.get_running_loop()
-    async with _SEMAPHORES["MAX_PROCESS"]:
-        with ThreadPoolExecutor(max_workers=1,
-                                thread_name_prefix="concat_thread",
-                                ) as pool:
-            path_traj = await loop.run_in_executor(pool, concat)
+    async with _SEMAPHORES["MAX_FILES_OPEN"]:
+        async with _SEMAPHORES["MAX_PROCESS"]:
+            with ThreadPoolExecutor(max_workers=1,
+                                    thread_name_prefix="concat_thread",
+                                    ) as pool:
+                path_traj = await loop.run_in_executor(pool, concat)
     return path_traj
 
 
@@ -397,11 +398,12 @@ class InPartsTrajectoryPropagator:
                                    tra_out=tra_out, struct_out=None,
                                    overwrite=overwrite)
         loop = asyncio.get_running_loop()
-        async with _SEMAPHORES["MAX_PROCESS"]:
-            with ThreadPoolExecutor(max_workers=1,
-                                    thread_name_prefix="concat_thread",
-                                    ) as pool:
-                full_traj = await loop.run_in_executor(pool, concat)
+        async with _SEMAPHORES["MAX_FILES_OPEN"]:
+            async with _SEMAPHORES["MAX_PROCESS"]:
+                with ThreadPoolExecutor(max_workers=1,
+                                        thread_name_prefix="concat_thread",
+                                        ) as pool:
+                    full_traj = await loop.run_in_executor(pool, concat)
         return full_traj
 
 
@@ -789,11 +791,12 @@ class ConditionalTrajectoryPropagator:
                                    tra_out=tra_out, struct_out=None,
                                    overwrite=overwrite)
         loop = asyncio.get_running_loop()
-        async with _SEMAPHORES["MAX_PROCESS"]:
-            with ThreadPoolExecutor(max_workers=1,
-                                    thread_name_prefix="concat_thread",
-                                    ) as pool:
-                full_traj = await loop.run_in_executor(pool, concat)
+        async with _SEMAPHORES["MAX_FILES_OPEN"]:
+            async with _SEMAPHORES["MAX_PROCESS"]:
+                with ThreadPoolExecutor(max_workers=1,
+                                        thread_name_prefix="concat_thread",
+                                        ) as pool:
+                    full_traj = await loop.run_in_executor(pool, concat)
         return full_traj, first_condition_fullfilled
 
     async def _condition_vals_for_traj(self, traj):

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -663,9 +663,10 @@ class Trajectory:
                                                     cache=self._memory_cache,
                                                              )
             # if we get until here we have no cache!
-            logger.warning(f"No cache associated with {self}. Returning "
-                           + "calculated function values anyway but no caching"
-                           + "can/will be performed!"
+            logger.warning("No cache associated with %s. Returning calculated "
+                           "function values anyway but no caching can/will be "
+                           "performed!",
+                           self,
                            )
             return await wrapped_func.get_values_for_trajectory(self)
 


### PR DESCRIPTION
this should avoid deadlocks when using 3 open files at a time (like when calling subprecesses with stdout, stdin, stderr).
Also add all gromacs mdp otions to the MDP class, they should now all have the correct types.