### PR TITLE
Use relative file paths to make moving of trajectories and data easier

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,13 @@ and many more. Note :py:class:`asyncmd.Trajectory` are unique objects in the
 sense that every combination of underlying ``trajectory_files`` will give you the
 same object back even if you instantiate it multiple times, i.e. ``is`` will be
 ``True`` for the two objects (in addition to ``==`` beeing ``True``).
+Also note that it is possible to pickle and unpickle :py:class:`asyncmd.Trajectory`
+objects. You can even change the filepath of the underlying trajectories, i.e.
+copy/move them to another location (consider also moving the npz cache files)
+and still unpickle to get a working :py:class:`asyncmd.Trajectory` object as
+long as the relative path between your python workdir and the trajectory files
+does not change. Or you can change the workdir of the python interpreter as long
+as the trajectory files remain at the same location in the filesystem.
 
 ..
    TODO: reference to the dev section where we explain the two hidden funcs

--- a/src/asyncmd/__about__.py
+++ b/src/asyncmd/__about__.py
@@ -63,7 +63,7 @@ __author_email__ = "hendrik.jung@biophys.mpg.de"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __copyright__ = "2022 {:s}".format(__author__)
 # sort out if we have a git (commit) version
-base_version = "0.2.1.rc1"
+base_version = "0.2.2"
 git_version = _get_git_version()
 if git_version is None:
     # no git installed

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -283,7 +283,7 @@ class GmxEngine(MDEngine):
     def workdir(self, value):
         if not os.path.isdir(value):
             raise TypeError(f"Not a directory ({value}).")
-        value = os.path.abspath(value)
+        value = os.path.relpath(value)
         self._workdir = value
 
     @property
@@ -294,7 +294,7 @@ class GmxEngine(MDEngine):
     def gro_file(self, val):
         if not os.path.isfile(val):
             raise FileNotFoundError(f"gro file not found: {val}")
-        val = os.path.abspath(val)
+        val = os.path.relpath(val)
         self._gro_file = val
 
     @property
@@ -305,7 +305,7 @@ class GmxEngine(MDEngine):
     def top_file(self, val):
         if not os.path.isfile(val):
             raise FileNotFoundError(f"top file not found: {val}")
-        val = os.path.abspath(val)
+        val = os.path.relpath(val)
         self._top_file = val
 
     @property
@@ -318,7 +318,7 @@ class GmxEngine(MDEngine):
             # GMX does not require an ndx file, so we accept None
             if not os.path.isfile(val):
                 raise FileNotFoundError(f"ndx file not found: {val}")
-            val = os.path.abspath(val)
+            val = os.path.relpath(val)
         # set it anyway (even if it is None)
         self._ndx_file = val
 
@@ -689,11 +689,11 @@ class GmxEngine(MDEngine):
         last_trajname = os.path.split(previous_trajs[-1].trajectory_files[0])[-1]
         last_partnum = int(last_trajname[len(deffnm) + 5:len(deffnm) + 9])
         if last_partnum != len(previous_trajs):
-            logger.warn("Not all previous trajectory parts seem to be present "
-                        + "in the current workdir. Assuming the highest part "
-                        + "number corresponds to the checkpoint file and "
-                        + "continuing anyway."
-                        )
+            logger.warning("Not all previous trajectory parts seem to be "
+                           + "present in the current workdir. Assuming the "
+                           + "highest part number corresponds to the "
+                           + "checkpoint file and continuing anyway."
+                           )
         # load the 'old' mdp_in
         async with _SEMAPHORES["MAX_FILES_OPEN"]:
             self._mdp = MDP(os.path.join(self.workdir, f"{deffnm}.mdp"))

--- a/src/asyncmd/mdconfig.py
+++ b/src/asyncmd/mdconfig.py
@@ -343,7 +343,7 @@ class LineBasedMDConfig(MDConfig):
     def original_file(self, value: str) -> None:
         # NOTE: (re)setting the file also replaces the current config with
         #       what we parse from that file
-        value = os.path.abspath(value)
+        value = os.path.relpath(value)
         if not os.path.isfile(value):
             raise ValueError(f"Can not access the file {value}")
         self._original_file = value
@@ -410,7 +410,7 @@ class LineBasedMDConfig(MDConfig):
         ValueError
             Raised when `overwrite=False` but `outfile` exists.
         """
-        outfile = os.path.abspath(outfile)
+        outfile = os.path.relpath(outfile)
         if os.path.exists(outfile) and not overwrite:
             raise ValueError(f"overwrite=False and file exists ({outfile}).")
         if not self.changed:

--- a/src/asyncmd/slurm.py
+++ b/src/asyncmd/slurm.py
@@ -512,7 +512,8 @@ class SlurmProcess:
     sbatch_executable = "sbatch"
     scancel_executable = "scancel"
 
-    def __init__(self, jobname: str, sbatch_script: str, workdir: str,
+    def __init__(self, jobname: str, sbatch_script: str,
+                 workdir: typing.Optional[str] = None,
                  time: typing.Optional[float] = None,
                  stdfiles_removal: str = "success",
                  **kwargs) -> None:
@@ -528,8 +529,9 @@ class SlurmProcess:
             SLURM jobname (``--job-name``).
         sbatch_script : str
             Absolute or relative path to a SLURM submission script.
-        workdir : str
-            Absolute or relative path to use as working directory.
+        workdir : str or None
+            Absolute or relative path to use as working directory. None will
+            result in using the current directory as workdir.
         time : float or None
             Timelimit for the job in hours. None will result in using the
             default as either specified in the sbatch script or the partition.
@@ -570,9 +572,11 @@ class SlurmProcess:
         # TODO/FIXME: do we want sbatch_script to be relative to wdir?
         #             (currently it is relative to current dir when creating
         #              the slurmprocess)
-        self.sbatch_script = os.path.relpath(sbatch_script)
+        self.sbatch_script = os.path.abspath(sbatch_script)
         # TODO: default to current dir when creating?
-        self.workdir = os.path.relpath(workdir)
+        if workdir is None:
+            workdir = os.getcwd()
+        self.workdir = os.path.abspath(workdir)
         self.time = time
         self.stdfiles_removal = stdfiles_removal
         self._jobid = None

--- a/src/asyncmd/slurm.py
+++ b/src/asyncmd/slurm.py
@@ -570,9 +570,9 @@ class SlurmProcess:
         # TODO/FIXME: do we want sbatch_script to be relative to wdir?
         #             (currently it is relative to current dir when creating
         #              the slurmprocess)
-        self.sbatch_script = os.path.abspath(sbatch_script)
+        self.sbatch_script = os.path.relpath(sbatch_script)
         # TODO: default to current dir when creating?
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.time = time
         self.stdfiles_removal = stdfiles_removal
         self._jobid = None

--- a/src/asyncmd/tools.py
+++ b/src/asyncmd/tools.py
@@ -38,10 +38,10 @@ def ensure_executable_available(executable: str) -> str:
     ValueError
         If the given name does not exist or can not be executed.
     """
-    if os.path.isfile(os.path.abspath(executable)):
+    if os.path.isfile(os.path.relpath(executable)):
         # see if it is a relative path starting from cwd
         # (or a full path starting with /)
-        executable = os.path.abspath(executable)
+        executable = os.path.relpath(executable)
         if not os.access(executable, os.X_OK):
             raise ValueError(f"{executable} must be executable.")
     elif shutil.which(executable) is not None:

--- a/src/asyncmd/tools.py
+++ b/src/asyncmd/tools.py
@@ -38,10 +38,10 @@ def ensure_executable_available(executable: str) -> str:
     ValueError
         If the given name does not exist or can not be executed.
     """
-    if os.path.isfile(os.path.relpath(executable)):
+    if os.path.isfile(os.path.abspath(executable)):
         # see if it is a relative path starting from cwd
         # (or a full path starting with /)
-        executable = os.path.relpath(executable)
+        executable = os.path.abspath(executable)
         if not os.access(executable, os.X_OK):
             raise ValueError(f"{executable} must be executable.")
     elif shutil.which(executable) is not None:

--- a/src/asyncmd/trajectory/convert.py
+++ b/src/asyncmd/trajectory/convert.py
@@ -112,11 +112,11 @@ class TrajectoryConcatenator:
         FileNotFoundError
             If ``struct_out`` given but the file is not accessible.
         """
-        tra_out = os.path.abspath(tra_out)
+        tra_out = os.path.relpath(tra_out)
         if os.path.exists(tra_out) and not overwrite:
             raise FileExistsError(f"overwrite=False and tra_out exists: {tra_out}")
         struct_out = (trajs[0].structure_file if struct_out is None
-                      else os.path.abspath(struct_out))
+                      else os.path.relpath(struct_out))
         if not os.path.isfile(struct_out):
             # although we would expect that it exists if it comes from an
             # existing traj, we still check to catch other unrelated issues :)
@@ -259,11 +259,11 @@ class FrameExtractor(abc.ABC):
         #       and also for modification?
         # TODO: should we make it possible to extract multiple frames, i.e.
         #       enable the use of slices (and iterables of indices?)
-        outfile = os.path.abspath(outfile)
+        outfile = os.path.relpath(outfile)
         if os.path.exists(outfile) and not overwrite:
             raise FileExistsError(f"overwrite=False but outfile={outfile} exists.")
         struct_out = (traj_in.structure_file if struct_out is None
-                      else os.path.abspath(struct_out))
+                      else os.path.relpath(struct_out))
         if not os.path.isfile(struct_out):
             # although we would expect that it exists if it comes from an
             # existing traj, we still check to catch other unrelated issues :)

--- a/src/asyncmd/trajectory/propagate.py
+++ b/src/asyncmd/trajectory/propagate.py
@@ -221,8 +221,9 @@ class _TrajectoryPropagator:
                                                     deffnm=deffnm,
                                                     file_ending=ending.upper(),
                                                            )
-            await asyncio.gather(*(aiofiles.os.unlink(os.path.join(workdir, f))
-                                   for f in parts_to_remove)
+            await asyncio.gather(*(aiofiles.os.unlink(f)
+                                   for f in parts_to_remove
+                                   )
                                  )
 
 

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -150,16 +150,16 @@ class Trajectory:
         #                        + f"mismatching type ({type(value)}). "
         #                        + f" Default type is {type(cval)}."
         #                        )
-        # TODO: already sanitized by __new__ when calculating the traj_hash
-        #       but we get the old (pre-sanitizing) value passed to __init__
-        #       (we could call init ourselfs in __new__? but that would mess
-        #        with pickling...?)
-        self._trajectory_files = self._sanitize_trajectory_files(trajectory_files)
-        if os.path.isfile(structure_file):
-            self._structure_file = os.path.relpath(structure_file)
-        else:
-            raise FileNotFoundError(f"structure_file ({structure_file}) must "
-                                    + "be accessible.")
+        # NOTE: self._trajectory_files is set in __new__ because we otherwise
+        #       would sanitize the files twice, but we need to check in __new__
+        #       to make pickling work
+        #       self._structure_file is also set in __new__ together with the
+        #       trajectory_files as we also sanitize its path
+        #       self._traj_hash and self._workdir are also set by __new__!
+        # self._trajectory_files
+        # self._structure_file
+        # self._workdir
+        # self._traj_hash
         # properties
         self.nstout = nstout  # use the setter to make basic sanity checks
         self._len = None
@@ -191,20 +191,48 @@ class Trajectory:
                 cache_type: typing.Optional[str] = None,
                 **kwargs):
         global _TRAJECTORIES_BY_HASH  # our global traj registry
-        trajectory_files = Trajectory._sanitize_trajectory_files(trajectory_files)
+        # see if old_workdir is given to sanitize file paths
+        old_workdir = kwargs.get("old_workdir", None)
+        # get cwd to get (and set) it only once for init and unpickle
+        current_workdir = os.path.abspath(os.getcwd())
+        trajectory_files, structure_file = Trajectory._sanitize_file_paths(
+                                            trajectory_files=trajectory_files,
+                                            structure_file=structure_file,
+                                            current_workdir=current_workdir,
+                                            old_workdir=old_workdir,
+                                                                           )
         traj_hash = Trajectory._calc_traj_hash(trajectory_files)
         try:
             # see if we (i.e. a traj with the same hash) are already existing
             other_traj = _TRAJECTORIES_BY_HASH[traj_hash]
             # if yes return 'ourself'
+            # (but make sure that the filepaths match even after a potential
+            #   change of workdir)
+            other_traj._trajectory_files = trajectory_files
+            other_traj._structure_file = structure_file
+            other_traj._workdir = current_workdir
             return other_traj
         except KeyError:
             # not yet in there, so need to create us
-            # we just create cls so that we will be "created" by init and
+            # we just create cls so that we will be "created" by init or
             # unpickled by setstate
+            # NOTE: we need to make sure that every attribute we set
+            #       below is not overwritten by setstate and/or init!
             obj = super().__new__(cls)
             # but set self._traj_hash so we dont recalculate it
             obj._traj_hash = traj_hash
+            # and set self._trajectory_files so we dont sanitize twice
+            obj._trajectory_files = trajectory_files
+            # also set self._structure_file
+            obj._structure_file = structure_file
+            # and set self._workdir to the new value
+            # Note:
+            # we remember the current workdir to be able to unpickle as long as
+            # either the relpath between traj and old/new workdir does not change
+            # or the trajectory did not change its location but we changed workdir
+            # (we need the workdir only for the second option)
+            obj._workdir = current_workdir
+            # and add us to the global trajectory registry
             _TRAJECTORIES_BY_HASH[traj_hash] = obj
             return obj
 
@@ -217,19 +245,68 @@ class Trajectory:
     #    _forget_trajectory(traj_hash=self.trajectory_hash)
 
     @classmethod
-    def _sanitize_trajectory_files(cls, trajectory_files) -> list[str]:
+    def _sanitize_file_paths(cls,
+                             trajectory_files: typing.Union[list[str], str],
+                             structure_file: str,
+                             current_workdir: typing.Optional[str] = None,
+                             old_workdir: typing.Optional[str] = None,
+                             ) -> typing.Tuple[list[str], str]:
+        # NOTE: this returns relpath if no old_workdir is given and the traj
+        #       is accessible
+        #       if old_workdir is given (and the traj not accesible) it (tries)
+        #       to find the traj by assuming the traj did not change place and
+        #       we just need to add the "path_diff" from old to new workdir to
+        #       the path, if the file is then still not there it raises a
+        #       FileNotFoundError
+        # NOTE: (for pickling and aimmd storage behavior):
+        #       The above makes it possible to either change the workdir of the
+        #       python session OR change the location of the trajectories as
+        #       as long as the relative path between trajectory and python
+        #       workdir does not change!
         if isinstance(trajectory_files, str):
             trajectory_files = [trajectory_files]
-        traj_files_sanitized = [os.path.relpath(traj_f)
-                                for traj_f in trajectory_files]
-        #traj_files_sanitized = []
-        #for traj_f in trajectory_files:
-        #    if os.path.isfile(traj_f):
-        #        traj_files_sanitized += [os.path.relpath(traj_f)]
-        #    else:
-        #        raise FileNotFoundError(f"Trajectory file ({traj_f}) must be "
-        #                                + "accessible.")
-        return traj_files_sanitized
+        if all(os.path.isfile(traj_f) for traj_f in trajectory_files):
+            # all trajectories are there at their path
+            # so just sanitize (== make relpath) and return
+            traj_files_sanitized = [os.path.relpath(traj_f)
+                                    for traj_f in trajectory_files
+                                    ]
+            if not os.path.isfile(structure_file):
+                raise FileNotFoundError(f"Structure file ({structure_file}) is"
+                                        " not accessible.")
+            struct_file_sanitized = os.path.relpath(structure_file)
+            return traj_files_sanitized, struct_file_sanitized
+        # if we get until here we might have changed the workdir between pickle
+        # unpickle, so lets try to add that in and hope the trajectories did
+        # not change their path
+        if old_workdir is not None:
+            if current_workdir is None:
+                raise ValueError("'old_workdir' given but 'current_workdir' "
+                                 "was None.")
+            path_diff = os.path.relpath(old_workdir, current_workdir)
+            traj_files_sanitized = [os.path.relpath(
+                                        os.path.join(path_diff, traj_f)
+                                                    )
+                                    for traj_f in trajectory_files
+                                    ]
+            struct_file_sanitized = os.path.relpath(
+                                        os.path.join(path_diff, structure_file)
+                                                    )
+            if all(os.path.isfile(f)
+                   for f in traj_files_sanitized + [struct_file_sanitized]
+                   ):
+                return traj_files_sanitized, struct_file_sanitized
+        # if we got until here we have a problem: either both the workdir and
+        # the traj paths have changed, but there would be no way of knowning
+        # this I (hejung) think
+        # Or (some of) the trajectories are not accessible, e.g. because a user
+        # passed a wrong path
+        raise FileNotFoundError(
+                    "Trajectory and structure files must exist, "
+                    f"but some of the trajectory_files ({trajectory_files}) "
+                    f"and/or the structure_file ({structure_file}) are not "
+                    "accessible."
+                                )
 
     @classmethod
     def _calc_traj_hash(cls, trajectory_files):
@@ -238,19 +315,13 @@ class Trajectory:
         # note that we do not include the structure file on purpose because
         # that allows for changing .gro <-> .tpr or similar
         # (which we expect to not change the calculated CV values)
-        # NOTE: We do however include the path(s) to the trajectory_files
-        #       as we can otherwise return a Trajectory object with different
-        #       trajectory_files than expected from __new__ when we create a
-        #       second Trajectory obj that has the same trajectory data, which
-        #       admitedtly is a corner case. However, as this would be very
-        #       confusing we happily pay the small price of potentially
-        #       calculating CV values slightly more often than necesary
         # TODO: how much should we read?
         #      (I [hejung] think the first and last .5 MB are enough)
         data = bytes()
         for traj_f in trajectory_files:
-            data += traj_f.encode("utf-8")
+            #data += traj_f.encode("utf-8")  # DONT include filepaths!...
             fsize = os.stat(traj_f).st_size
+            data += str(fsize).encode("utf-8")
             if fsize == 0:
                 # Note: we could also just warn as long as we do not do the
                 #       negative seek below if filesize == 0. However,
@@ -350,11 +421,11 @@ class Trajectory:
         elif self._cache_type == "h5py":
             try:
                 h5py_cache = _GLOBALS["H5PY_CACHE"]
-            except KeyError:
+            except KeyError as exc:
                 raise ValueError(
                     "No h5py cache file registered yet. Try calling "
                     + "``asyncmd.config.register_h5py_cache_file()``"
-                    + " with the appropriate arguments first")
+                    + " with the appropriate arguments first") from exc
             if self._h5py_cache is None:
                 # dont have one yet so setup the cache
                 self._h5py_cache = TrajectoryFunctionValueCacheH5PY(
@@ -440,8 +511,8 @@ class Trajectory:
             self._fix_trr_xtc_step_wraparound(universe=u)
         else:
             # bail out if traj is not an XTC or TRR
-            logger.info(f"{self} is not of type XTC or TRR. Not applying "
-                        + "wraparound fix.")
+            logger.info("%s is not of type XTC or TRR. Not applying "
+                        "wraparound fix.", self)
         # make sure the trajectory is closed by MDAnalysis
         u.trajectory.close()
 
@@ -554,24 +625,6 @@ class Trajectory:
         if self.trajectory_hash != other.trajectory_hash:
             # if it has a different hash it cant be equal
             return False
-        # if they dont have the same number of trajecory files they can not be
-        # the same
-        if len(self.trajectory_files) != len(other.trajectory_files):
-            return False
-        # they might be the same file (bitwise) but at different locations in
-        # the FS, then they are not equal (at least for out purposes)
-        for traj_f_self, traj_f_other in zip(self.trajectory_files,
-                                             other.trajectory_files):
-            if traj_f_self != traj_f_other:
-                return False
-        # NOTE: we allow the structure file to change
-        #       this way we consider e.g. the same traj with a gro and with a
-        #       tpr (or whatever) as structure files as equal
-        #       The rationale is that MDAnalysis will ocmplain if the struct
-        #       and the traj dont match and we e.g. reuse cached values without
-        #       checking the structure file anyway
-        #if self.structure_file != other.structure_file:
-        #    return False
         # TODO: check for cached CV values? I (hejung) think it does not really
         #       make sense...
 
@@ -738,7 +791,14 @@ class Trajectory:
         return state
 
     def __setstate__(self, d: dict):
-        self.__dict__ = d
+        # remove the attributes we set in __new__ from dict
+        # (otherwise we would overwrite what we set in __new__)
+        del d["_trajectory_files"]
+        del d["_structure_file"]
+        del d["_workdir"]
+        del d["_traj_hash"]
+        # now we can update without overwritting what we set in __new__
+        self.__dict__.update(d)
         # sort out which cache we were using (and which we will use now)
         if self._using_default_cache_type:
             # if we were using the global default when pickling use it now too
@@ -758,11 +818,12 @@ class Trajectory:
                 # Note that this will not err but just emit the warning to log
                 # when we change the cache but it will err when the global
                 # default cache is set to h5py (as above)
-                logger.warning(f"Trying to unpickle {self} with cache_type "
-                               + "'h5py' not possible without a registered "
-                               + "cache. Falling back to global default type."
-                               + "See 'asyncmd.config.register_h5py_cache' and"
-                               + " 'asyncmd.config.set_default_cache_type'."
+                logger.warning("Trying to unpickle %s with cache_type "
+                               "'h5py' not possible without a registered "
+                               "cache. Falling back to global default type."
+                               "See 'asyncmd.config.register_h5py_cache' and"
+                               " 'asyncmd.config.set_default_cache_type'.",
+                                self
                                )
                 self.cache_type = None  # this calls _setup_cache
                 return  # get out of here, no need to setup the cache twice
@@ -779,6 +840,7 @@ class Trajectory:
                      "structure_file": self.structure_file,
                      "nstout": self.nstout,
                      "cache_type": self.cache_type,
+                     "old_workdir": self._workdir,
                      })
 
 
@@ -885,9 +947,11 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
         # now if the old npz did not match we should remove it
         # then we will rewrite it with the first cached CV values
         if not existing_npz_matches:
-            logger.debug(f"Found existing npz file ({self.fname_npz}) but the"
-                         + " trajectory hash does not match."
-                         + " Recreating the npz cache from scratch.")
+            logger.debug("Found existing npz file (%s) but the"
+                         " trajectory hash does not match."
+                         " Recreating the npz cache from scratch.",
+                         self.fname_npz
+                         )
             os.unlink(self.fname_npz)
 
     @classmethod

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -782,8 +782,12 @@ class Trajectory:
         # (otherwise we would overwrite what we set in __new__)
         del d["_trajectory_files"]
         del d["_structure_file"]
-        del d["_workdir"]
         del d["_traj_hash"]
+        try:
+            del d["_workdir"]
+        except KeyError:
+            # 'old' trajectory objects dont have a _workdir attribute
+            pass
         # now we can update without overwritting what we set in __new__
         self.__dict__.update(d)
         # sort out which cache we were using (and which we will use now)

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -252,6 +252,9 @@ class Trajectory:
             data += traj_f.encode("utf-8")
             fsize = os.stat(traj_f).st_size
             if fsize == 0:
+                # Note: we could also just warn as long as we do not do the
+                #       negative seek below if filesize == 0. However,
+                #       mdanalysis throws errors for empty trajectories anyway
                 raise ValueError(f"Trajectory file {traj_f} is of size 0.")
             with open(traj_f, "rb") as traj_file:
                 # read the first .5 MB of each file

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -156,7 +156,7 @@ class Trajectory:
         #        with pickling...?)
         self._trajectory_files = self._sanitize_trajectory_files(trajectory_files)
         if os.path.isfile(structure_file):
-            self._structure_file = os.path.abspath(structure_file)
+            self._structure_file = os.path.relpath(structure_file)
         else:
             raise FileNotFoundError(f"structure_file ({structure_file}) must "
                                     + "be accessible.")
@@ -220,12 +220,12 @@ class Trajectory:
     def _sanitize_trajectory_files(cls, trajectory_files) -> list[str]:
         if isinstance(trajectory_files, str):
             trajectory_files = [trajectory_files]
-        traj_files_sanitized = [os.path.abspath(traj_f)
+        traj_files_sanitized = [os.path.relpath(traj_f)
                                 for traj_f in trajectory_files]
         #traj_files_sanitized = []
         #for traj_f in trajectory_files:
         #    if os.path.isfile(traj_f):
-        #        traj_files_sanitized += [os.path.abspath(traj_f)]
+        #        traj_files_sanitized += [os.path.relpath(traj_f)]
         #    else:
         #        raise FileNotFoundError(f"Trajectory file ({traj_f}) must be "
         #                                + "accessible.")
@@ -576,12 +576,12 @@ class Trajectory:
 
     @property
     def structure_file(self) -> str:
-        """Return absolute path to the structure file."""
+        """Return relative path to the structure file."""
         return copy.copy(self._structure_file)
 
     @property
     def trajectory_files(self) -> str:
-        """Return absolute path to the trajectory files."""
+        """Return relative path to the trajectory files."""
         return copy.copy(self._trajectory_files)
 
     @property
@@ -892,14 +892,14 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
         Parameters
         ----------
         fname_trajs : list[str]
-            Absolute path to the trajectory for which we cache.
+            Path to the trajectory for which we cache.
         trajectory_hash : int
             Hash of the trajectory (files).
 
         Returns
         -------
         str
-            Absolute path to the cachefile associated with trajectory.
+            Path to the cachefile associated with trajectory.
         """
         head, tail = os.path.split(fname_trajs[0])
         hash_part = str(trajectory_hash)[:5]


### PR DESCRIPTION
Use relative file paths everywhere to make it easier to move around trajectories (and their cache files) without loosing cached CV values.

It is now also supported to either change the directory where the trajectories/structure files are stored as long as the relative path to the python workdir does not change OR to change the python workdir in between pickle and unpickle of a trajectory.