### PR TITLE
Trajectory propagators automatically remove asyncmd CV cache files and MDAnalysis offset files for removed trajectory parts

### DIFF
--- a/src/asyncmd/__about__.py
+++ b/src/asyncmd/__about__.py
@@ -63,7 +63,7 @@ __author_email__ = "hendrik.jung@biophys.mpg.de"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __copyright__ = "2022 {:s}".format(__author__)
 # sort out if we have a git (commit) version
-base_version = "0.2.2"
+base_version = "0.3.0"
 git_version = _get_git_version()
 if git_version is None:
     # no git installed

--- a/src/asyncmd/tools.py
+++ b/src/asyncmd/tools.py
@@ -14,6 +14,7 @@
 # along with asyncmd. If not, see <https://www.gnu.org/licenses/>.
 import os
 import shutil
+import aiofiles
 
 
 def ensure_executable_available(executable: str) -> str:
@@ -51,3 +52,35 @@ def ensure_executable_available(executable: str) -> str:
         raise ValueError(f"{executable} must be an existing path or accesible "
                          + "via the $PATH environment variable.")
     return executable
+
+
+def remove_file_if_exist(f: str):
+    """
+    Remove a given file if it exists.
+
+    Parameters
+    ----------
+    f : str
+        Path to the file to remove.
+    """
+    try:
+        os.remove(f)
+    except FileNotFoundError:
+        # TODO: should we info/warn if the file is not there?
+        pass
+
+
+async def remove_file_if_exist_async(f: str):
+    """
+    Remove a given file if it exists asynchronously.
+
+    Parameters
+    ----------
+    f : str
+        Path to the file to remove.
+    """
+    try:
+        await aiofiles.os.remove(f)
+    except FileNotFoundError:
+        # TODO: should we info/warn if the file is not there?
+        pass

--- a/src/asyncmd/trajectory/propagate.py
+++ b/src/asyncmd/trajectory/propagate.py
@@ -244,18 +244,32 @@ class _TrajectoryPropagator:
             #       could remove the wildcard "trajectories" and replace it by
             #       their specific trajectory file ending, i.e. we would need
             #       to know all potential traj file endings to be sure
+            if remove_mda_offset_and_lock_files or remove_asyncmd_npz_caches:
+                # create list with head, tail filenames only if needed
+                f_splits = [os.path.split(f) for f in parts_to_remove]
             if remove_mda_offset_and_lock_files:
-                offset_lock_files_to_remove = ["." + f + "_offsets.npz"
-                                               for f in parts_to_remove]
-                offset_lock_files_to_remove += ["." + f + "_offsets.lock"
-                                                for f in parts_to_remove]
+                offset_lock_files_to_remove = [os.path.join(
+                                                 f_head,
+                                                 "." + f_tail + "_offsets.npz",
+                                                            )
+                                               for f_head, f_tail in f_splits
+                                               ]
+                offset_lock_files_to_remove += [os.path.join(
+                                                  f_head,
+                                                  "." + f_tail + "_offsets.lock",
+                                                             )
+                                                for f_head, f_tail in f_splits
+                                                ]
             else:
                 offset_lock_files_to_remove = []
             if remove_asyncmd_npz_caches:
                 # NOTE: we do not try to remove the multipart traj caches since
                 #       the Propagators only return non-multipart Trajectories
-                npz_caches_to_remove = ["." + f + "_asyncmd_cv_cache.npz"
-                                        for f in parts_to_remove
+                npz_caches_to_remove = [os.path.join(
+                                          f_head,
+                                          "." + f_tail + "_asyncmd_cv_cache.npz",
+                                                     )
+                                        for f_head, f_tail in f_splits
                                         ]
             else:
                 npz_caches_to_remove = []

--- a/src/asyncmd/trajectory/propagate.py
+++ b/src/asyncmd/trajectory/propagate.py
@@ -24,8 +24,13 @@ import numpy as np
 from .trajectory import Trajectory
 from .functionwrapper import TrajectoryFunctionWrapper
 from .convert import TrajectoryConcatenator
-from ..utils import (get_all_traj_parts, get_all_file_parts,
-                     nstout_from_mdconfig)
+from ..utils import (get_all_traj_parts,
+                     get_all_file_parts,
+                     nstout_from_mdconfig,
+                     )
+from ..tools import (remove_file_if_exist,
+                     remove_file_if_exist_async,
+                     )
 
 
 logger = logging.getLogger(__name__)
@@ -176,6 +181,8 @@ class _TrajectoryPropagator:
     async def remove_parts(self, workdir: str, deffnm: str,
                            file_endings_to_remove: list[str] = ["trajectories",
                                                                 "log"],
+                            remove_mda_offset_and_lock_files: bool = True,
+                            remove_asyncmd_npz_caches: bool = True,
                            ) -> None:
         """
         Remove all `$deffnm.part$num.$file_ending` files for given file_endings
@@ -223,6 +230,37 @@ class _TrajectoryPropagator:
                                                            )
             await asyncio.gather(*(aiofiles.os.unlink(f)
                                    for f in parts_to_remove
+                                   )
+                                 )
+            # TODO: the note below?
+            # NOTE: this is a bit hacky: we just try to remove the offset and
+            #       lock files for every file we remove (since we do not know
+            #       if the file we remove is a trajectory [and therefore
+            #        potentially has corresponding offset and lock files] or if
+            #       the file we remove is e.g. an edr which has no lock/offset)
+            #       If we would know that we are removing a trajectory we could
+            #       try the removal only there, however even by comparing with
+            #       `traj_type` (from above) we can not be certain since users
+            #       could remove the wildcard "trajectories" and replace it by
+            #       their specific trajectory file ending, i.e. we would need
+            #       to know all potential traj file endings to be sure
+            if remove_mda_offset_and_lock_files:
+                offset_lock_files_to_remove = ["." + f + "_offsets.npz"
+                                               for f in parts_to_remove]
+                offset_lock_files_to_remove += ["." + f + "_offsets.lock"
+                                                for f in parts_to_remove]
+            else:
+                offset_lock_files_to_remove = []
+            if remove_asyncmd_npz_caches:
+                # NOTE: we do not try to remove the multipart traj caches since
+                #       the Propagators only return non-multipart Trajectories
+                npz_caches_to_remove = ["." + f + "_asyncmd_cv_cache.npz"
+                                        for f in parts_to_remove
+                                        ]
+            else:
+                npz_caches_to_remove = []
+            await asyncio.gather(*(remove_file_if_exist_async(f)
+                                   for f in offset_lock_files_to_remove + npz_caches_to_remove
                                    )
                                  )
 

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -885,6 +885,8 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
     #       immutable (except for adding additional stored function values)
     #       but we assume that the actual underlying trajectory stays the same,
     #       i.e. it is not extended after first storing it
+    #       If it changes between two npz-cache initializiations, it will have
+    #       a different traj-hash and all cached CV values will be recalculated
 
     # NOTE: npz appending inspired by: https://stackoverflow.com/a/66618141
 
@@ -896,13 +898,13 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
     #    too it does not really matter (as they can not be async either)?
     # ...and as we also leave some room for non-semaphored file openings anyway
 
-    def __init__(self, fname_trajs: str, hash_traj: int) -> None:
+    def __init__(self, fname_trajs: list[str], hash_traj: int) -> None:
         """
         Initialize a `TrajectoryFunctionValueCacheNPZ`.
 
         Parameters
         ----------
-        fname_trajs : str
+        fname_trajs : list[str]
             Absolute filenames to the trajectories for which we cache CV values.
         hash_traj : int
             Hash over the first part of the trajectory file,
@@ -970,8 +972,9 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
             Path to the cachefile associated with trajectory.
         """
         head, tail = os.path.split(fname_trajs[0])
-        hash_part = str(trajectory_hash)[:5]
-        return os.path.join(head, f".{tail}_{hash_part}_asyncmd_cv_cache.npz")
+        return os.path.join(head,
+            f".{tail}_{'MULTIPART' if len(fname_trajs) > 1 else ''}_asyncmd_cv_cache.npz"
+                            )
 
     def __len__(self) -> int:
         return len(self._func_ids)

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -973,7 +973,7 @@ class TrajectoryFunctionValueCacheNPZ(collections.abc.Mapping):
         """
         head, tail = os.path.split(fname_trajs[0])
         return os.path.join(head,
-            f".{tail}_{'MULTIPART' if len(fname_trajs) > 1 else ''}_asyncmd_cv_cache.npz"
+            f".{tail}{'_MULTIPART' if len(fname_trajs) > 1 else ''}_asyncmd_cv_cache.npz"
                             )
 
     def __len__(self) -> int:


### PR DESCRIPTION
Add an option to TrajectoryPropagators to automatically remove asyncmd CV cache files and MDAnalysis offset files for removed trajectory parts. This also changes the naming for asyncmd npz CV cache files to not include the trajectory hash anymore (to make it easier to remove the files associated with the removed trajectory parts). 