### PR TITLE
Slurm quality of live improvements

### DIFF
--- a/src/asyncmd/config.py
+++ b/src/asyncmd/config.py
@@ -20,7 +20,7 @@ import typing
 
 
 from ._config import _GLOBALS, _SEMAPHORES
-from .slurm import set_slurm_settings
+from .slurm import set_slurm_settings, set_all_slurm_settings
 # TODO: Do we want to set the _GLOBALS defaults here? E.g. CACHE_TYPE="npz"?
 
 

--- a/src/asyncmd/slurm.py
+++ b/src/asyncmd/slurm.py
@@ -50,6 +50,13 @@ class SlurmSubmissionError(SlurmError):
 # NOTE: these are the sacct states (they differ from the squeue states)
 #       cf. https://slurm.schedmd.com/sacct.html#lbAG
 #       and https://slurm.schedmd.com/squeue.html#lbAG
+# NOTE on error codes:
+#      we return:
+#       - None if the job has not finished
+#       - 0 if it completed successfully
+#       - 1 if the job failed (probably) due to user error (or we dont know)
+#       - 2 if the job failed (almost certainly) due to cluster/node-issues as
+#         recognized/detected by slurm
 _SLURM_STATE_TO_EXITCODE = {
     "BOOT_FAIL": 1,  # Job terminated due to launch failure
     # Job was explicitly cancelled by the user or system administrator.
@@ -61,7 +68,7 @@ _SLURM_STATE_TO_EXITCODE = {
     # Job terminated with non-zero exit code or other failure condition.
     "FAILED": 1,
     # Job terminated due to failure of one or more allocated nodes.
-    "NODE_FAIL": 1,
+    "NODE_FAIL": 2,
     "OUT_OF_MEMORY": 1,  # Job experienced out of memory error.
     "PENDING": None,  # Job is awaiting resource allocation.
     # NOTE: preemption means interupting a process to later restart it,

--- a/src/asyncmd/slurm.py
+++ b/src/asyncmd/slurm.py
@@ -183,7 +183,7 @@ class SlurmClusterMediator:
         # now make the regexps
         self._ecode_for_slurmstate_regexps = {
                             e_code: re.compile(regexp_str,
-                                               flags=re.IGNORECASE | re.DOTALL,
+                                               flags=re.IGNORECASE,
                                                )
                             for e_code, regexp_str in regexp_strings.items()
                                                }
@@ -195,7 +195,7 @@ class SlurmClusterMediator:
             \|\|\|\|  # the (first) separator (we set 4 "|" as separator)
             .*$ # and we dont care what the rest is until the newline
             """,
-            flags=re.VERBOSE | re.MULTILINE | re.DOTALL,
+            flags=re.VERBOSE | re.MULTILINE,
                                                       )
 
     @property

--- a/src/asyncmd/slurm.py
+++ b/src/asyncmd/slurm.py
@@ -1078,22 +1078,25 @@ async def create_slurmprocess_submit(jobname: str,
     return proc
 
 
-def set_slurm_settings(sinfo_executable: str = "sinfo",
-                       sacct_executable: str = "sacct",
-                       sbatch_executable: str = "sbatch",
-                       scancel_executable: str = "scancel",
-                       min_time_between_sacct_calls: int = 10,
-                       num_fails_for_broken_node: int = 3,
-                       success_to_fail_ratio: int = 50,
-                       exclude_nodes: typing.Optional[list[str]] = None,
-                       ) -> None:
+def set_all_slurm_settings(sinfo_executable: str = "sinfo",
+                           sacct_executable: str = "sacct",
+                           sbatch_executable: str = "sbatch",
+                           scancel_executable: str = "scancel",
+                           min_time_between_sacct_calls: int = 10,
+                           num_fails_for_broken_node: int = 3,
+                           success_to_fail_ratio: int = 50,
+                           exclude_nodes: typing.Optional[list[str]] = None,
+                           ) -> None:
     """
     (Re) initialize all settings relevant for SLURM job control.
 
     Call this function if you want to change e.g. the path/name of SLURM
     executables. Note that this is a conviencence function to set all SLURM
-    settings in one central place, you could also set each setting seperately
-    in the `SlurmProcess` and `SlurmClusterMediator` classes.
+    settings in one central place and all at once, i.e. calling this function
+    will overwrite all previous settings.
+    If this is not intended, have a look at the `set_slurm_settings` function
+    which only changes the passed arguments or you can also set/modify each
+    setting separately in the `SlurmProcess` and `SlurmClusterMediator` classes.
 
     Parameters
     ----------
@@ -1129,3 +1132,62 @@ def set_slurm_settings(sinfo_executable: str = "sinfo",
                                                                 )
     SlurmProcess.sbatch_executable = sbatch_executable
     SlurmProcess.scancel_executable = scancel_executable
+
+
+def set_slurm_settings(sinfo_executable: typing.Optional[str] = None,
+                       sacct_executable: typing.Optional[str] = None,
+                       sbatch_executable: typing.Optional[str] = None,
+                       scancel_executable: typing.Optional[str] = None,
+                       min_time_between_sacct_calls: typing.Optional[int] = None,
+                       num_fails_for_broken_node: typing.Optional[int] = None,
+                       success_to_fail_ratio: typing.Optional[int] = None,
+                       exclude_nodes: typing.Optional[list[str]] = None,
+                       ) -> None:
+    """
+    Set single or multiple settings relevant for SLURM job control.
+
+    Call this function if you want to change e.g. the path/name of SLURM
+    executables. This function only modifies thoose settings for which a value
+    other than None is passed. See `set_all_slurm_settings` if you want to set/
+    modify all slurm settings and/or reset them to their defaults.
+
+    Parameters
+    ----------
+    sinfo_executable : str, optional
+        Name of path to the sinfo executable, by default None.
+    sacct_executable : str, optional
+        Name or path to the sacct executable, by default None.
+    sbatch_executable : str, optional
+        Name or path to the sbatch executable, by default None.
+    scancel_executable : str, optional
+        Name or path to the scancel executable, by default None.
+    min_time_between_sacct_calls : int, optional
+        Minimum time (in seconds) between subsequent sacct calls,
+        by default None.
+    num_fails_for_broken_node : int, optional
+        Number of failed jobs we need to observe per node before declaring it
+        to be broken (and not submitting any more jobs to it), by default None.
+    success_to_fail_ratio : int, optional
+        Number of successful jobs we need to observe per node to decrease the
+        failed job counter by one, by default None.
+    exclude_nodes : list[str], optional
+        List of nodes to exclude in job submissions, by default None, which
+        results in no excluded nodes.
+    """
+    global SlurmProcess
+    if sinfo_executable is not None:
+        SlurmProcess._slurm_cluster_mediator.sinfo_executable = sinfo_executable
+    if sacct_executable is not None:
+        SlurmProcess._slurm_cluster_mediator.sacct_executable = sacct_executable
+    if sbatch_executable is not None:
+        SlurmProcess.sbatch_executable = sbatch_executable
+    if scancel_executable is not None:
+        SlurmProcess.scancel_executable = scancel_executable
+    if min_time_between_sacct_calls is not None:
+        SlurmProcess._slurm_cluster_mediator.min_time_between_sacct_calls = min_time_between_sacct_calls
+    if num_fails_for_broken_node is not None:
+        SlurmProcess._slurm_cluster_mediator.num_fails_for_broken_node = num_fails_for_broken_node
+    if success_to_fail_ratio is not None:
+        SlurmProcess._slurm_cluster_mediator.success_to_fail_ratio = success_to_fail_ratio
+    if exclude_nodes is not None:
+        SlurmProcess._slurm_cluster_mediator.exclude_nodes = exclude_nodes

--- a/src/asyncmd/trajectory/functionwrapper.py
+++ b/src/asyncmd/trajectory/functionwrapper.py
@@ -475,6 +475,13 @@ class SlurmTrajectoryFunctionWrapper(TrajectoryFunctionWrapper):
                                                    result_file=result_file,
                                                    slurm_workdir=tra_dir,
                                                                               )
+            if returncode == 2:
+                logger.error("Exit code indicating node fail from CV batch job"
+                             " for executable %s on trajectory %s (slurm jobid"
+                             " %s). stderr was: %s. stdout was: %s",
+                             self.executable, traj, slurm_proc.slurm_jobid,
+                             stdout.decode(), stderr.decode(),
+                             )
         if returncode != 0:
             # Can not be exitcode 2, because of the while loop above
             raise RuntimeError(


### PR DESCRIPTION
- make it possible to set list of excluded nodes via call to config methods
- add an additional slurm config function and improve behavior of previous slurm config func (to only set those settings that are passed instead of all to their defaults).
- return error codes depending on if the slurm-job crashed due to a node/hardware failure or some other reason
- resubmit SlurmTrajectoryFunctionCV calculations if slurm-jobs crashed due to node/hardware failure
- use re-module to match slurm-states in sacct output (slightly faster and more resilient)