### PR TITLE
Improve MDEngine API consistency and fix rare Trajectory caching bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- GmxEngine `apply_constraints` and `generate_velocities` methods: rename `wdir` argument to `workdir` to make it consistent with `prepare` and `prepare_from_files` (also add the `workdir` argument to the MDEngine ABC).
+
 ## [0.4.1] - 2025-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GmxEngine `apply_constraints` and `generate_velocities` methods: rename `wdir` argument to `workdir` to make it consistent with `prepare` and `prepare_from_files` (also add the `workdir` argument to the MDEngine ABC).
 
+### Fixed
+
+- a rare condition that could result in the same `TrajectoryFunctionWrapper` being applied twice to the same `Trajectory`, which resulted in unnecessary computations and a ValuesAlreadyStoredError when trying to cache the calculated values twice.
+
 ## [0.4.1] - 2025-07-29
 
 ### Added

--- a/src/asyncmd/config.py
+++ b/src/asyncmd/config.py
@@ -28,9 +28,10 @@ import typing
 from ._config import (_GLOBALS, _SEMAPHORES, _OPT_SEMAPHORES,
                       _GLOBALS_KEYS, _SEMAPHORES_KEYS, _OPT_SEMAPHORES_KEYS,
                       )
-from .trajectory.trajectory import (_update_cache_type_for_all_trajectories,
-                                    _deregister_h5py_cache_for_all_trajectories,
-                                    )
+from .trajectory.trajectory import (
+    update_cache_type_for_all_trajectories as _update_cache_type_for_all_trajectories,
+    deregister_h5py_cache_for_all_trajectories as _deregister_h5py_cache_for_all_trajectories,
+    )
 from .trajectory.trajectory_cache import (
         TrajectoryFunctionValueCacheInH5PY as _TrajectoryFunctionValueCacheInH5PY,
         )

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -438,7 +438,7 @@ class GmxEngine(MDEngine):
         return self._engine_state.frames_done
 
     async def apply_constraints(self, conf_in: Trajectory, conf_out_name: str, *,
-                                wdir: str = ".") -> Trajectory:
+                                workdir: str = ".") -> Trajectory:
         """
         Apply constraints to given configuration.
 
@@ -448,7 +448,7 @@ class GmxEngine(MDEngine):
             A (one-frame) trajectory, only the first frame will be used.
         conf_out_name : str
             Output path for the constrained configuration.
-        wdir : str, optional
+        workdir : str
             Working directory for the constraint engine, by default ".",
             a subfolder with random name will be created.
 
@@ -459,13 +459,13 @@ class GmxEngine(MDEngine):
         """
         return await self._0step_md(conf_in=conf_in,
                                     conf_out_name=conf_out_name,
-                                    wdir=wdir,
+                                    wdir=workdir,
                                     constraints=True,
                                     generate_velocities=False,
                                     )
 
     async def generate_velocities(self, conf_in: Trajectory, conf_out_name: str, *,
-                                  wdir: str = ".", constraints: bool = True,
+                                  workdir: str = ".", constraints: bool = True,
                                   ) -> Trajectory:
         """
         Generate random Maxwell-Boltzmann velocities for given configuration.
@@ -476,10 +476,10 @@ class GmxEngine(MDEngine):
             A (one-frame) trajectory, only the first frame will be used.
         conf_out_name : str
             Output path for the velocity randomized configuration.
-        wdir : str, optional
+        workdir : str
             Working directory for the constraint engine, by default ".",
             a subfolder with random name will be created.
-        constraints : bool, optional
+        constraints : bool
             Whether to also apply constraints, by default True.
 
         Returns
@@ -490,7 +490,7 @@ class GmxEngine(MDEngine):
         """
         return await self._0step_md(conf_in=conf_in,
                                     conf_out_name=conf_out_name,
-                                    wdir=wdir,
+                                    wdir=workdir,
                                     constraints=constraints,
                                     generate_velocities=True,
                                     )

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -466,10 +466,13 @@ class GmxEngine(MDEngine):
                                     )
 
     async def generate_velocities(self, conf_in: Trajectory, conf_out_name: str, *,
-                                  workdir: str = ".", constraints: bool = True,
+                                  workdir: str = ".",
                                   ) -> Trajectory:
         """
         Generate random Maxwell-Boltzmann velocities for given configuration.
+
+        This also applies constraints to the configuration (as gromacs does when
+        generating velocities).
 
         Parameters
         ----------
@@ -480,19 +483,16 @@ class GmxEngine(MDEngine):
         workdir : str
             Working directory for the constraint engine, by default ".",
             a subfolder with random name will be created.
-        constraints : bool
-            Whether to also apply constraints, by default True.
 
         Returns
         -------
         Trajectory
-            The configuration with random velocities and optionally constraints
-            enforced.
+            The configuration with random velocities and constraints enforced.
         """
         return await self._0step_md(conf_in=conf_in,
                                     conf_out_name=conf_out_name,
                                     wdir=workdir,
-                                    constraints=constraints,
+                                    constraints=True,
                                     generate_velocities=True,
                                     )
 

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -43,7 +43,7 @@ from ..tools import (
     DescriptorOutputTrajType as _DescriptorOutputTrajType,
 )
 from ..trajectory.trajectory import Trajectory
-from ..trajectory import NoModificationFrameExtractor
+from ..trajectory.convert import NoModificationFrameExtractor
 from .mdconfig import MDP
 from .utils import get_all_traj_parts, nstout_from_mdp
 

--- a/src/asyncmd/gromacs/mdengine.py
+++ b/src/asyncmd/gromacs/mdengine.py
@@ -43,6 +43,7 @@ from ..tools import (
     DescriptorOutputTrajType as _DescriptorOutputTrajType,
 )
 from ..trajectory.trajectory import Trajectory
+from ..trajectory import NoModificationFrameExtractor
 from .mdconfig import MDP
 from .utils import get_all_traj_parts, nstout_from_mdp
 
@@ -498,9 +499,6 @@ class GmxEngine(MDEngine):
     async def _0step_md(self, conf_in: Trajectory, conf_out_name: str, *,
                         wdir: str, constraints: bool, generate_velocities: bool,
                         ) -> Trajectory:
-        if not os.path.isabs(conf_out_name):
-            # assume conf_out is to be meant relative to wdir if not an abspath
-            conf_out_name = os.path.join(wdir, conf_out_name)
         # work in a subdirectory of wdir to make deleting easy
         # generate its name at random to make sure we can use multiple
         # engines with 0stepMDruns in the same wdir
@@ -560,21 +558,30 @@ class GmxEngine(MDEngine):
                     + "\n--------\n"
                     + f"stdout: \n--------\n {stdout.decode()}"
                                          )
-            # just get the output trajectory, it is only one configuration
-            shutil.move(os.path.join(swdir, (f"{run_name}{self._num_suffix(1)}"
-                                             + f".{conf_out_name.split('.')[-1]}")
-                                     ),
-                        conf_out_name)
-            shutil.rmtree(swdir)  # remove the whole directory we used as wdir
-            return Trajectory(
-                              trajectory_files=conf_out_name,
-                              # structure file of the conf_in because we
-                              # delete the other one with the folder
-                              structure_file=conf_in.structure_file,
-                              nstout=1,
-                              )
+            # just get the output trajectory, it should only be one configuration
+            # Note: we get the full-precision traj from gromacs and let
+            # the FrameExtractor (i.e. MDAnalysis) handle any potential conversions
+            engine_traj = Trajectory(
+                            trajectory_files=os.path.join(
+                                swdir, f"{run_name}{self._num_suffix(1)}.trr"
+                                ),
+                            structure_file=conf_in.structure_file,
+                            )
+            extractor = NoModificationFrameExtractor()
+            # Note: we use extract (and not extract_async) because otherwise
+            #       it can happen in super-rare circumstances that the Trajectory
+            #       we just instantiated is "replaced" by a Trajectory with the
+            #       same hash but a different filename/path, then the extraction
+            #       fails. If we dont await this can not happen since we do not
+            #       give up control in between.
+            out_traj = extractor.extract(outfile=conf_out_name,
+                                         traj_in=engine_traj,
+                                         idx=len(engine_traj) - 1,
+                                         )
+            return out_traj
         finally:
             await self._cleanup_gmx_mdrun(workdir=swdir, run_name=run_name)
+            shutil.rmtree(swdir)  # remove the whole directory we used as wdir
 
     async def prepare(self, starting_configuration: Trajectory | None | str,
                       workdir: str, deffnm: str) -> None:

--- a/src/asyncmd/mdengine.py
+++ b/src/asyncmd/mdengine.py
@@ -34,8 +34,8 @@ class MDEngine(abc.ABC):
     Abstract base class to define a common interface for all :class:`MDEngine`.
     """
     @abc.abstractmethod
-    async def apply_constraints(self, conf_in: Trajectory,
-                                conf_out_name: str) -> Trajectory:
+    async def apply_constraints(self, conf_in: Trajectory, conf_out_name: str, *,
+                                workdir: str = ".") -> Trajectory:
         """
         Apply constraints to given conf_in, write conf_out_name and return it.
 
@@ -43,6 +43,7 @@ class MDEngine(abc.ABC):
         ----------
         conf_in : Trajectory
         conf_out_name : str
+        workdir: str
 
         Returns
         -------

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -214,6 +214,7 @@ class Trajectory:
            "memory": TrajectoryFunctionValueCacheInMemory,
     }
     _file_data: _TrajectoryFileData  # type annotation for stuff we set in __new__
+    _semaphores_by_func_id: collections.defaultdict[str, asyncio.BoundedSemaphore]
 
     # Note: We want __init__ and __new__ to have the same call signature
     #       (at least for users, __new__ takes `old_workdir`...).
@@ -258,18 +259,20 @@ class Trajectory:
         #       The _TrajectoryFileData dataclass therefore contains everything
         #       (and only those things) we need in __new__
         # self._file_data
+        # NOTE:
+        # self._semaphores_by_func_id is also set by __new__, because otherwise
+        # we could have a (rare) condition in which we overwrite the dict with
+        # a fresh dict in __init__ for an existing Trajectory that just in this
+        # moment already has a function applied to it (i.e. a semaphore bound).
+        # Then we could apply the same func twice because the two invocations
+        # would get different dicts and could both get a different semaphore.
+        # self._semaphores_by_func_id
         # properties
         self.nstout = nstout  # use the setter to make basic sanity checks
         # store for all (immutable) properties we read from the trajectory files
         self._property_data: None | _TrajectoryPropertyData = None
         # setup cache for functions applied to this traj
         self._cache = self._setup_cache()
-        # Locking mechanism such that only one application of a specific
-        # CV func can run at any given time on this trajectory
-        self._semaphores_by_func_id: collections.defaultdict[
-            str,
-            asyncio.BoundedSemaphore,
-        ] = collections.defaultdict(asyncio.BoundedSemaphore)
 
     def __new__(cls,
                 trajectory_files: list[str] | str, structure_file: str,
@@ -313,6 +316,10 @@ class Trajectory:
                                     workdir=current_workdir,
                                     trajectory_hash=traj_hash,
                                     )
+            # Setup locking mechanism such that only one application of a specific
+            # CV func can run at any given time on this trajectory
+            obj._semaphores_by_func_id = collections.defaultdict(
+                                                    asyncio.BoundedSemaphore)
             # and add us to the global trajectory registry
             _TRAJECTORIES_BY_HASH[traj_hash] = obj
             return obj
@@ -847,9 +854,6 @@ class Trajectory:
                     # ignore if we already have them
                     pass
         state["_cache"] = None
-        state["_semaphores_by_func_id"] = collections.defaultdict(
-                                                    asyncio.BoundedSemaphore
-                                                                  )
         return state
 
     def __setstate__(self, d: dict) -> None:

--- a/src/asyncmd/trajectory/trajectory.py
+++ b/src/asyncmd/trajectory/trajectory.py
@@ -64,9 +64,9 @@ def clear_all_cache_values_for_all_trajectories() -> None:
         traj.clear_all_cache_values()
 
 
-def _update_cache_type_for_all_trajectories(copy_content: bool = True,
-                                            clear_old_cache: bool = False,
-                                            ) -> None:
+def update_cache_type_for_all_trajectories(copy_content: bool = True,
+                                           clear_old_cache: bool = False,
+                                           ) -> None:
     """
     Update the cache type for each :class:`Trajectory` currently in existence.
 
@@ -89,8 +89,8 @@ def _update_cache_type_for_all_trajectories(copy_content: bool = True,
                                )
 
 
-def _deregister_h5py_cache_for_all_trajectories(h5py_group: "h5py.File | h5py.Group"
-                                                ) -> None:
+def deregister_h5py_cache_for_all_trajectories(h5py_group: "h5py.File | h5py.Group"
+                                               ) -> None:
     """
     Deregister the given h5py_group as cache from all :class:`Trajectory` objects.
 
@@ -100,7 +100,7 @@ def _deregister_h5py_cache_for_all_trajectories(h5py_group: "h5py.File | h5py.Gr
         The h5py_group to deregister.
     """
     for traj in _TRAJECTORIES_BY_HASH.values():
-        traj._deregister_h5py_cache(h5py_group)
+        traj.deregister_h5py_cache(h5py_group)
 
 
 def _forget_all_trajectories() -> None:
@@ -550,14 +550,14 @@ class Trajectory:
         """
         self._cache.clear_all_values()
 
-    def _deregister_h5py_cache(self, h5py_group: "h5py.File | h5py.Group") -> None:
+    def deregister_h5py_cache(self, h5py_group: "h5py.File | h5py.Group") -> None:
         """
-        Deregister the given h5py_cache as a source of cached values.
+        Deregister the given h5py_group as a source of cached values.
 
         Parameters
         ----------
-        h5py_cache : h5py.File | h5py.Group
-            The h5py_cache to deregister/remove from caching
+        h5py_group : h5py.File | h5py.Group
+            The h5py_group to deregister/remove from caching
 
         Raises
         ------


### PR DESCRIPTION
- GmxEngine `apply_constraints` and `generate_velocities` methods: rename `wdir` argument to `workdir` to make it consistent with `prepare` and `prepare_from_files` (also add the `workdir` argument to the MDEngine ABC).

- fixed a rare condition that could result in the same `TrajectoryFunctionWrapper` being applied twice to the same `Trajectory`, which resulted in unnecessary computations and a ValuesAlreadyStoredError when trying to cache the calculated values twice.